### PR TITLE
Report formatting

### DIFF
--- a/R/limma_report.R
+++ b/R/limma_report.R
@@ -50,9 +50,6 @@ make_limma_reports <- function(model_results = NULL,
   setwd(output_dir)
 
   cli::cli_inform("Copying resources to output directory {.path {output_dir}}")
-  if (!dir.exists("resources")) {
-    dir.create("resources")
-  }
   if (!dir.exists("static_plots")) {
     dir.create("static_plots")
   }
@@ -63,9 +60,6 @@ make_limma_reports <- function(model_results = NULL,
   file.copy(from = system.file("report_templates/limma_report_per_contrast.Rmd",
                                package = "proteomicsDIA"),
             to = "report_template.Rmd", overwrite = T)
-  file.copy(from = system.file("report_templates/logo_higherres.png",
-                               package = "proteomicsDIA"),
-            to = "resources/logo_higherres.png", overwrite = T)
 
   contrast_count <- 1
   num_contrasts <- length(names(model_results$stats_by_contrast))

--- a/inst/report_templates/limma_report_per_contrast.Rmd
+++ b/inst/report_templates/limma_report_per_contrast.Rmd
@@ -4,8 +4,7 @@ pagetitle: "`r contrast`"
 output: 
   html_document:
     mathjax: null
-    self_contained: false
-    lib_dir: resources
+    self_contained: true
 ---
 
 ```{r setup, message=FALSE, warning=FALSE, echo = F, include = F}
@@ -21,7 +20,8 @@ knitr::opts_chunk$set(warning = F, message = F, fig.align = "center", echo = F, 
 ```
 
 ```{r logo, fig.align="left", out.width="40%"}
-knitr::include_graphics(path = "resources/logo_higherres.png")
+knitr::include_graphics(path = system.file("report_templates/logo_higherres.png",
+                                           package = "proteomicsDIA"), rel_path = F)
 ```
 
 ### `r stringr::str_replace(contrast, "_vs_", " vs ")` 


### PR DESCRIPTION
This pull request changes the format of our end-user HTML reports. First, it switches the order of the plots, putting the adjusted-p-value plots before the raw-p-value ones. Second, it makes the HTML files self-contained, That is, they now contain all their javascript and other dependencies, which before were kept in a separate resources folder. The resulting files are thus a little bit bigger (by ~1.5Mb), but they are now fully portable.

This fixes issues #43 and #44 