### PR TITLE
remove extra annotation rows from excel output

### DIFF
--- a/R/limma_tables.R
+++ b/R/limma_tables.R
@@ -433,7 +433,7 @@ write_limma_excel <- function(filename, statlist, annotation, data, norm.method,
   # Add annotation columns -----------------------------------------------------
 
   # Subset and rename
-  annot <- annotation[, annotCols]
+  annot <- annotation[1:nrow(data), annotCols]
   colnames(annot) <- newNames
   annot <- make_excel_hyperlinks(data = annot,
                                  url.col = "UniProt ID",


### PR DESCRIPTION
This PR fixes #58, in which the Excel output had extra rows of proteins in the annotation section for which there were not statistical results.