### PR TITLE
make missing data NA from the start

### DIFF
--- a/R/data_import.R
+++ b/R/data_import.R
@@ -336,7 +336,7 @@ extract_protein_data <- function(data,
   ## contain text 'Missing Value' if the protein does not have detectable expression.
   ## replace 'Missing Value' with zeros, remove comma's, convert data in each column
   ## to numeric values
-  rawData[,][rawData[,]=="Missing Value"] <- 0
+  rawData[,][rawData[,]=="Missing Value"] <- NA
   for(i in 1:ncol(rawData)){ rawData[,i] <- remove_commas(rawData[,i]) }
 
 

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -236,7 +236,7 @@ filter_data <- function(data,
   cli::cli_inform("Keeping only protein entries with intensity > 0 in at least {.val {min.reps}} sample{?s} {cli::qty(min.reps)} in at least {.val {min.grps}} group{?s} {cli::qty(min.grps)}")
 
   ## FILTERING
-  ## zeros are replaced with NA
+  ## zeros, if they exist, are replaced with NA
   tmpData <- data_in_targets
   tmpData[,][tmpData[,] == 0] <- NA
 


### PR DESCRIPTION
This PR fixes #8: now, missing data are imported as NA straightaway, instead of being imported as 0 and then later changed to NA. I think this 0 behavior was needed for the creation of big query files in the `extract_data()` function, but now that we're not making big query files in that function we an go straight to the desired NA. 