### PR TITLE
write_norm_report now saves normQCmetrics as in the tags

### DIFF
--- a/R/normalization_plotting.R
+++ b/R/normalization_plotting.R
@@ -37,7 +37,6 @@ eval_pn_metric_for_plot <- function(normList,
   }
 
   plotData$method <- factor(plotData$method, levels = names(normList))
-
   return(plotData)
 }
 
@@ -198,7 +197,7 @@ pn_plot_PEV <- function(normList, grouping) {
 #' @rdname pn_plots
 #' @keywords internal
 #'
-pn_plot_COR <- function(normList, grouping) {
+pn_plot_COR <- function(normList, DAlist, grouping) {
   eval_pn_metric_for_plot(normList,
                           grouping,
                           metric = "COR") |>

--- a/R/normalization_report.R
+++ b/R/normalization_report.R
@@ -151,6 +151,16 @@ write_norm_report <- function(DAList,
   e <- pn_plot_log2ratio(normList, groups)
   f <- pn_plot_log2ratio(normList, groups, zoom = T, legend = !suppress_zoom_legend)
 
+  # Add QC metrics to tags
+  DAList$tags$normQCmetrics <- list()
+  DAList$tags$normQCmetrics$grouping_column <- grouping_column
+  DAList$tags$normQCmetrics$PCV <- eval_pn_metric_for_plot(normList, groups, metric="PCV")
+  DAList$tags$normQCmetrics$PMAD <- eval_pn_metric_for_plot(normList, groups, metric="PMAD")
+  DAList$tags$normQCmetrics$PEV <- eval_pn_metric_for_plot(normList, groups, metric="PEV")
+  DAList$tags$normQCmetrics$COR <- eval_pn_metric_for_plot(normList, groups, metric="COR")
+
+
+  
 
 
   page_1 <- a + b + c + d + e + f +
@@ -182,7 +192,7 @@ write_norm_report <- function(DAList,
     cli::cli_abort(c("Failed to create {.path {file.path(output_dir, filename)}}"))
   }
 
-  invisible(input_DAList)
+  return(DAList)
 }
 
 

--- a/R/normalization_report.R
+++ b/R/normalization_report.R
@@ -152,12 +152,7 @@ write_norm_report <- function(DAList,
   f <- pn_plot_log2ratio(normList, groups, zoom = T, legend = !suppress_zoom_legend)
 
   # Add QC metrics to tags
-  DAList$tags$normQCmetrics <- list()
-  DAList$tags$normQCmetrics$grouping_column <- grouping_column
-  DAList$tags$normQCmetrics$PCV <- eval_pn_metric_for_plot(normList, groups, metric="PCV")
-  DAList$tags$normQCmetrics$PMAD <- eval_pn_metric_for_plot(normList, groups, metric="PMAD")
-  DAList$tags$normQCmetrics$PEV <- eval_pn_metric_for_plot(normList, groups, metric="PEV")
-  DAList$tags$normQCmetrics$COR <- eval_pn_metric_for_plot(normList, groups, metric="COR")
+  DAList <- save_norm_metrics(DAList, grouping_column)
 
 
   
@@ -192,7 +187,7 @@ write_norm_report <- function(DAList,
     cli::cli_abort(c("Failed to create {.path {file.path(output_dir, filename)}}"))
   }
 
-  return(DAList)
+  validate_DAList(DAList)
 }
 
 
@@ -230,3 +225,16 @@ apply_all_normalizations <- function(data) {
   normList
 }
 
+save_norm_metrics <- function(DAList, grouping_column){
+  normList <- apply_all_normalizations(data=DAList$data)
+  groups <- as.character(DAList$metadata[,grouping_column])
+  DAList$tags$normQCmetrics <- list()
+  DAList$tags$normQCmetrics$grouping_column <- list()
+  names(DAList$tags$normQCmetrics)[1] <- grouping_column
+  DAList$tags$normQCmetrics[[grouping_column]]$PCV <- eval_pn_metric_for_plot(normList, groups, metric="PCV")
+  DAList$tags$normQCmetrics[[grouping_column]]$PMAD <- eval_pn_metric_for_plot(normList, groups, metric="PMAD")
+  DAList$tags$normQCmetrics[[grouping_column]]$PEV <- eval_pn_metric_for_plot(normList, groups, metric="PEV")
+  DAList$tags$normQCmetrics[[grouping_column]]$COR <- eval_pn_metric_for_plot(normList, groups, metric="COR")
+#  invisible(validate_DAList(DAList))
+  return(DAList)
+}


### PR DESCRIPTION
ByrumLab/proteoDA_uams#2 

Stephanie requested access to the actual numbers from the write_norm_report. So as a first step I added the QC values to the tags

DAList$tags$normQCmetrics contains 4 elements grouping_column, PCV, PMAD, PEV, COR

however, this does require the saving of a new DAList to occur

DAList <- write_norm_report()

If we go with this implementation then the next step would be to write out the metrics into a table.

Alternatively, I could redo the PR with a version that just prints the metrics to a file and doesn't save to values into a tag.