### PR TITLE
Update Rbuildignore to reflect new package name

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,4 @@
-^proteomicsDIA\.Rproj$
+^proteoDA\.Rproj$
 ^\.Rproj\.user$
 ^README\.Rmd$
 ^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ License: GPL (>= 3)
 biocViews:
 Imports:
     circlize,
-    cli,
+    cli (>= 3.6.0),
     ComplexHeatmap,
     ggplot2,
     ggrepel,


### PR DESCRIPTION
and require latest version of CLI to avoid a cryptic error with old versions