### PR TITLE
Default output dir 188

### DIFF
--- a/R/limma_report.R
+++ b/R/limma_report.R
@@ -11,7 +11,7 @@
 #'   gives information on how to group samples for the interactive
 #'   abundance plot.
 #' @param output_dir The directory in which to create the reports and save the
-#'   plot files. No defaults, must be specified.
+#'   plot files. If not specified, will default to the current working directory.
 #' @param tmp_subdir The subdirectory within the output directory in which to
 #'   store temporary files. Deleted by default. Default is "tmp".
 #' @param key_column Optional. The name of a column in the annotation data frame which gives
@@ -101,6 +101,15 @@ write_limma_plots <- function(DAList = NULL,
     cli::cli_abort(c("{.arg width} must be a numeric value greater > 0."))
   }
 
+  # defauly output dir if not provided
+  if (is.null(output_dir)) {
+    output_dir <- getwd()
+    cli::cli_inform("{.arg output_dir} argument is empty.")
+    cli::cli_inform("Setting output directory to current working directory:")
+    cli::cli_inform("{.path {output_dir}}")
+  }
+
+
   # TODO: add output filename validation once we decide on directory format
   if (!dir.exists(output_dir)) {
     dir.create(output_dir)
@@ -109,10 +118,12 @@ write_limma_plots <- function(DAList = NULL,
   old_wd <- getwd()
   on.exit(expr = setwd(old_wd), add = T)
 
+  if (output_dir != old_wd) {
+    cli::cli_inform("Setting working directory to output directory:")
+    cli::cli_inform("{.path {file.path(old_wd, output_dir)}}")
+    setwd(output_dir)
+  }
 
-
-  cli::cli_inform("Setting working directory to {.path {file.path(old_wd, output_dir)}}")
-  setwd(output_dir)
 
   cli::cli_inform("Copying resources to output directory {.path {output_dir}}")
   if (!dir.exists("static_plots")) {
@@ -211,8 +222,10 @@ write_limma_plots <- function(DAList = NULL,
 
   cli::cli_inform("Removing temporary files from {.path {output_dir}}")
   unlink(c("logo_higherres.png", "plot_template.Rmd", "report_template.Rmd", tmp_subdir), recursive = T)
-  cli::cli_inform("Returning working directory to {.path {old_wd}}")
-  setwd(old_wd)
+  if (getwd() != old_wd) {
+    cli::cli_inform("Returning working directory to {.path {old_wd}}")
+    setwd(old_wd)
+  }
 
   invisible(input_DAList)
 }

--- a/R/limma_tables.R
+++ b/R/limma_tables.R
@@ -15,8 +15,7 @@
 #'
 #' @param DAList A DAList object, with statistical results in the results slot.
 #' @param output_dir The directory in which to output tables. If not specified,
-#'   defaults to "protein_analysis/02_diff_abundance" in the current
-#'   working directory.
+#'   will default to the current working directory.
 #' @param overwrite Should results files be overwritten? Default is FALSE.
 #' @param contrasts_subdir The subdirectory within output_dir to write the per-contrast
 #'   result .csv files. If not specified, will be "per_contrast_results".
@@ -76,8 +75,12 @@ write_limma_tables <- function(DAList,
 
   # Assign defaults if not overridden above
   if (is.null(output_dir)) {
-    output_dir <- file.path("protein_analysis","02_diff_abundance")
+    output_dir <- getwd()
+    cli::cli_inform("{.arg output_dir} argument is empty.")
+    cli::cli_inform("Setting output directory to current working directory:")
+    cli::cli_inform("{.path {output_dir}}")
   }
+
   if (is.null(contrasts_subdir)) {
     contrasts_subdir <- "per_contrast_results"
   }
@@ -104,7 +107,7 @@ write_limma_tables <- function(DAList,
 
   if (dir.exists(output_dir)) {
     if (overwrite) {
-      cli::cli_inform("Directory {.path {output_dir}} already exists. {.arg overwrite} == {.val {overwrite}}. Overwriting files in directory.")
+      cli::cli_inform("Directory {.path {output_dir}} already exists. {.arg overwrite} == {.val {overwrite}}. Overwriting results files in directory.")
     } else {
       cli::cli_abort(c("Directory {.path {output_dir}} already exists",
                        "!" = "and {.arg overwrite} == {.val {overwrite}}",

--- a/R/normalization_report.R
+++ b/R/normalization_report.R
@@ -13,21 +13,22 @@
 #'
 #' @param DAList A DAList.
 #' @param grouping_column The name of the column in the metadata which
-#'   gives information on how to group samples for normalization. Must be supplied:
-#'   some metrics can't be calculated for only one group.
+#'   gives information on how to group samples for normalization. Must be
+#'   supplied: some metrics can't be calculated for only one group.
 #' @param overwrite Should report file be overwritten if it already exists?
 #'   Default is FALSE.
-#' @param output_dir The directory in which to save the report. If not provided,
-#'   will default to "protein_analysis/01_quality_control". If the directory does not
-#'   exist, it will be created.
-#' @param filename The file name of the report to be saved. Must end in .pdf. Will
-#'   default to "proteiNorm_Report.pdf" if no file name is provided.
+#' @param output_dir The directory in which to save the report. If the directory
+#'   does not exist, it will be created. If not provided, will default to
+#'   the current working directory.
+#' @param filename The file name of the report to be saved. Must end in .pdf.
+#'   Will default to "normalization_report.pdf" if no file name is provided.
 #' @param suppress_zoom_legend Should the legend be removed from the zoomed
 #'   log2ratio plot? Default is FALSE.
 #' @param use_ggrastr Should the \code{ggrastr} package be used to decrease
 #'   file size? Default is FALSE. Requires installation of \code{ggrastr}.
 #'
-#' @return If report is created successfully, invisibly returns the input DAList.
+#' @return If report is created successfully, invisibly returns the
+#'   input DAList.
 #'
 #' @importFrom ggplot2 ggsave
 #'
@@ -99,12 +100,14 @@ write_norm_report <- function(DAList,
 
   # Set default dir if not provided
   if (is.null(output_dir)) {
-    output_dir <- file.path("protein_analysis", "01_quality_control")
-    cli::cli_inform(cli::col_yellow("{.arg output_dir} argument is empty. Setting output directory to: {.path {output_dir}}"))
+    output_dir <- getwd()
+    cli::cli_inform("{.arg output_dir} argument is empty.")
+    cli::cli_inform("Setting output directory to current working directory:")
+    cli::cli_inform("{.path {output_dir}}")
   }
   # Set default report name if not provided
   if (is.null(filename)) {
-    filename <- "proteiNorm_Report.pdf"
+    filename <- "normalization_report.pdf"
     cli::cli_inform(cli::col_yellow("{.arg filename} argument is empty. Saving report to: {.path {output_dir}/{filename}}"))
   }
 

--- a/R/qc_report.R
+++ b/R/qc_report.R
@@ -133,8 +133,10 @@ write_qc_report <- function(DAList,
 
   # Set default dir if not provided
   if (is.null(output_dir)) {
-    output_dir <- file.path("protein_analysis", "01_quality_control")
-    cli::cli_inform(cli::col_yellow("{.arg output_dir} argument is empty. Setting output directory to: {.path {output_dir}}"))
+    output_dir <- getwd()
+    cli::cli_inform("{.arg output_dir} argument is empty.")
+    cli::cli_inform("Setting output directory to current working directory:")
+    cli::cli_inform("{.path {output_dir}}")
   }
 
   # Set default report name if not provided

--- a/man/write_limma_plots.Rd
+++ b/man/write_limma_plots.Rd
@@ -22,7 +22,7 @@ gives information on how to group samples for the interactive
 abundance plot.}
 
 \item{output_dir}{The directory in which to create the reports and save the
-plot files. No defaults, must be specified.}
+plot files. If not specified, will default to the current working directory.}
 
 \item{tmp_subdir}{The subdirectory within the output directory in which to
 store temporary files. Deleted by default. Default is "tmp".}

--- a/man/write_limma_tables.Rd
+++ b/man/write_limma_tables.Rd
@@ -19,8 +19,7 @@ write_limma_tables(
 \item{DAList}{A DAList object, with statistical results in the results slot.}
 
 \item{output_dir}{The directory in which to output tables. If not specified,
-defaults to "protein_analysis/02_diff_abundance" in the current
-working directory.}
+will default to the current working directory.}
 
 \item{overwrite}{Should results files be overwritten? Default is FALSE.}
 

--- a/man/write_norm_report.Rd
+++ b/man/write_norm_report.Rd
@@ -18,15 +18,15 @@ write_norm_report(
 \item{DAList}{A DAList.}
 
 \item{grouping_column}{The name of the column in the metadata which
-gives information on how to group samples for normalization. Must be supplied:
-some metrics can't be calculated for only one group.}
+gives information on how to group samples for normalization. Must be
+supplied: some metrics can't be calculated for only one group.}
 
-\item{output_dir}{The directory in which to save the report. If not provided,
-will default to "protein_analysis/01_quality_control". If the directory does not
-exist, it will be created.}
+\item{output_dir}{The directory in which to save the report. If the directory
+does not exist, it will be created. If not provided, will default to
+the current working directory.}
 
-\item{filename}{The file name of the report to be saved. Must end in .pdf. Will
-default to "proteiNorm_Report.pdf" if no file name is provided.}
+\item{filename}{The file name of the report to be saved. Must end in .pdf.
+Will default to "normalization_report.pdf" if no file name is provided.}
 
 \item{overwrite}{Should report file be overwritten if it already exists?
 Default is FALSE.}
@@ -38,7 +38,8 @@ log2ratio plot? Default is FALSE.}
 file size? Default is FALSE. Requires installation of \code{ggrastr}.}
 }
 \value{
-If report is created successfully, invisibly returns the input DAList.
+If report is created successfully, invisibly returns the
+input DAList.
 }
 \description{
 Saves a PDF report containing a variety of plots which give

--- a/man/write_qc_report.Rd
+++ b/man/write_qc_report.Rd
@@ -30,9 +30,9 @@ supplied, all samples will be the same color.}
 which contains labels to use for plotting figures. When not supplied,
 defaults to using the column names of the data in processed_data.}
 
-\item{output_dir}{The directory in which to save the report. If not provided,
-will default to "protein_analysis/01_quality_control". If the directory does not
-exist, it will be created.}
+\item{output_dir}{The directory in which to save the report. If the directory
+does not exist, it will be created. If not provided, will default to
+the current working directory.}
 
 \item{filename}{The file name of the report to be saved. Must end in .pdf. Will
 default to "QC_Report.pdf" if no filename is provided.}

--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -148,6 +148,12 @@ write_qc_report(full_higgs_chain,
                 overwrite = T)
 
 write_qc_report(full_higgs_chain,
+                output_dir = "temp",
+                color_column = "group",
+                filename = "higgs_qc_update.pdf",
+                overwrite = T)
+
+write_qc_report(full_higgs_chain,
                 color_column = "group",
                 label_column = "sampleIDs",
                 filename = "higgs_qc_update_samplelabs.pdf",

--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -334,6 +334,10 @@ write_limma_plots(results_reb,
                   grouping_column = "group",
                   output_dir = "reb_s3obj", key_column = "Protein.Name")
 
+write_limma_plots(results_reb,
+                  grouping_column = "group",
+                  key_column = "Protein.Name")
+
 write_limma_plots(results_kaul,
                   grouping_column = "group",
                   output_dir = "kaul_s3obj/")
@@ -359,6 +363,11 @@ write_limma_plots(results_ndu_random,
 write_limma_plots(results_zhan,
                   grouping_column = "group",
                   output_dir = "zhan_s3obj")
+
+write_limma_plots(results_zhan,
+                  grouping_column = "group")
+
+
 
 write_limma_plots(results_zhan,
                   grouping_column = "group",

--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -86,12 +86,13 @@ filtered_kaul <- filter_proteins_by_group(sub_kaul, min_reps = 4, min_groups = 2
 # Normalization report ----------------------------------------------------
 # Higgs
 write_norm_report(filtered_higgs,
-                        grouping_column = "group",
-                        file = "higgs_update_2.pdf", overwrite = T)
+                  grouping_column = "group",
+                  file = "higgs_update_2.pdf", overwrite = T)
 
 
 # Ndu
 write_norm_report(filtered_ndu,
+                  output_dir = "temp",
                         grouping_column = "group",
                         file = "ndu_update_with_points_ggrastr.pdf", overwrite = T, use_ggrastr = T)
 

--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -304,7 +304,6 @@ names(results_higgs$results)
 
 # Write results -----------------------------------------------------------
 write_limma_tables(results_lupashin,
-                   output_dir = "Lupashin_s3obj",
                    overwrite = T)
 
 write_limma_tables(results_ndu,


### PR DESCRIPTION
The PR updates the default output directories for our various write_* functions that output reports and tables. Now, if an output directory is not provided, the default is to inform the user with a message that everything will be saved to the current working directory, and then output to the current working directory. There are also a couple minor fixes in here to clean up messages related to working directory switching in the write_limma_results() function. This PR fixes #188.