### PR TITLE
Limma report file checks 196

### DIFF
--- a/R/add_contrasts.R
+++ b/R/add_contrasts.R
@@ -97,7 +97,7 @@ add_contrasts <- function(DAList,
                      "i" = "Check for typos in the contrasts",
                      "i" = "Make sure all groups for which you define contrasts are included in the design matrix.",
                      "i" = "Use {.code colnames(DAList$design$design_matrix)} to see the names of the design matrix.",
-                     "i" = "If using an intercpet model, you may need to reorder/relevel your factors."))
+                     "i" = "If using an intercept model, you may need to reorder/relevel your factors."))
   }
 
   # Get contrasts with limma

--- a/R/limma_report.R
+++ b/R/limma_report.R
@@ -221,6 +221,8 @@ write_limma_plots <- function(DAList = NULL,
 
     } else {
       cli::cli_inform("Results files already exist, and {.arg overwrite} == {.val {overwrite}}. Overwriting results files.")
+      # Delete old results files so results don't become unsynced if there are any issues
+      unlink(expected_results)
     }
   }
 

--- a/man/write_limma_plots.Rd
+++ b/man/write_limma_plots.Rd
@@ -11,6 +11,7 @@ write_limma_plots(
   title_column = NULL,
   output_dir = NULL,
   tmp_subdir = "tmp",
+  overwrite = FALSE,
   height = 1000,
   width = 1000
 )
@@ -41,6 +42,8 @@ plot files. If not specified, will default to the current working directory.}
 
 \item{tmp_subdir}{The subdirectory within the output directory in which to
 store temporary files. Deleted by default. Default is "tmp".}
+
+\item{overwrite}{Should results files be overwritten? Default is FALSE.}
 
 \item{height}{The height of the interactive report objects, in pixels.
 Default is 1000.}

--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -299,10 +299,10 @@ results_higgs <- extract_DA_results(fit_higgs, extract_intercept = F)
 
 
 # Write results -----------------------------------------------------------
-write_limma_tables(results_lupashin)
+write_limma_tables(results_lupashin, overwrite = T)
 
 write_limma_tables(results_ndu,
-                   overwrite = T)
+                   overwrite = F)
 
 write_limma_tables(results_ndu_random,
                    output_dir = "Ndu_random_s3obj",

--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -278,7 +278,6 @@ fit_ndu_random <- norm_ndu |>
 full_higgs_chain <- read_DIA_data("for_testing/Example Data/09_Higgs_072721_DIA_AG/Samples Report of Higgs_072721.csv") |>
   add_metadata("for_testing/Example Data/09_Higgs_072721_DIA_AG/metadata.csv") |>
   filter_samples(group != "Pool") |>
-  filter_proteins_contaminants() |>
   filter_proteins_by_group(min_reps = 4, min_groups = 3) |>
   filter_proteins_by_group(min_reps = 5, min_groups = 3) |>
   filter_proteins_by_proportion(min_prop = 1) |>
@@ -297,13 +296,10 @@ results_zhan <- extract_DA_results(fit_zhan)
 results_reb <- extract_DA_results(fit_reb)
 results_kaul <- extract_DA_results(fit_kaul)
 results_higgs <- extract_DA_results(fit_higgs, extract_intercept = F)
-names(results_higgs$results)
-
 
 
 # Write results -----------------------------------------------------------
-write_limma_tables(results_lupashin,
-                   overwrite = T)
+write_limma_tables(results_lupashin)
 
 write_limma_tables(results_ndu,
                    overwrite = T)
@@ -333,10 +329,12 @@ write_limma_tables(results_higgs,
 write_limma_plots(results_reb,
                   grouping_column = "group",
                   output_dir = "reb_s3obj",
-                  title_column = "Accession.Number")
+                  title_column = "Accession.Number", overwrite = T)
 
 write_limma_plots(results_reb,
                   grouping_column = "group")
+write_limma_plots(results_reb,
+                  grouping_column = "group", overwrite = T)
 
 write_limma_plots(results_reb,
                   output_dir = "many_cols",


### PR DESCRIPTION
This PR adds in overwriting and file creation checks for write_limma_report, and also improves the overwriting checks in write_limma_tables so that all overwriting is done at a per-file rather than per-directory levels. This works better with the default output directory (current wd) and allows people to save reports and tables in the same directory if they want. 

This PR fixes #196 