### PR TITLE
add_contrasts and add_design delete existing model fits and results,

### DIFF
--- a/R/add_contrasts.R
+++ b/R/add_contrasts.R
@@ -111,6 +111,19 @@ add_contrasts <- function(DAList,
     DAList$design$contrast_vector <- NULL
   }
 
+  # Delete any existing model fits and results, which may no longer match the
+  # contrasts
+  if (!is.null(DAList$eBayes_fit)) {
+    cli::cli_inform("DAList contains a model fit, deleting.")
+    # Get rid of any old stuff
+    DAList["eBayes_fit"] <- list(NULL)
+  }
+  if (!is.null(DAList$results)) {
+    cli::cli_inform("DAList contains a statistical results, deleting.")
+    # Get rid of any old stuff
+    DAList["results"] <- list(NULL)
+  }
+
   # Set everything here
   DAList$design$contrast_matrix <- contrasts
   DAList$design$contrast_vector <- contrasts_vector

--- a/R/add_design.R
+++ b/R/add_design.R
@@ -78,8 +78,21 @@ add_design <- function(DAList,
   if (!is.null(DAList$design)) {
     cli::cli_inform("DAList already contains a statistical design. Overwriting.")
     # Get rid of any old stuff
-    DAList$design <- NA
+    DAList["design"] <- list(NULL)
   }
+
+  # Delete any old model fits or results, which may no longer match the design.
+  if (!is.null(DAList$eBayes_fit)) {
+    cli::cli_inform("DAList contains a model fit, deleting.")
+    # Get rid of any old stuff
+    DAList["eBayes_fit"] <- list(NULL)
+  }
+  if (!is.null(DAList$results)) {
+    cli::cli_inform("DAList contains a statistical results, deleting.")
+    # Get rid of any old stuff
+    DAList["results"] <- list(NULL)
+  }
+
 
   DAList$design <- list(design_formula = paste0(as.character(formula), collapse = ""),
                         design_matrix = design_matrix)

--- a/tests/testthat/test-add_contrasts.R
+++ b/tests/testthat/test-add_contrasts.R
@@ -81,6 +81,60 @@ test_that("add_contrasts notifies user when overwriting an existing contrast", {
   )
 })
 
+
+# warning when deleting existing model fit
+test_that("add_contrasts gives warning when deleting existing model fit", {
+  input <- suppressMessages(
+    readRDS(test_path("fixtures", "add_design_input.rds")) |>
+      add_design(~ 0 + treatment) |>
+      fit_limma_model()
+  )
+  suppressMessages(
+    expect_message(
+      add_contrasts(input,
+                    contrasts_vector = c("Treatment_vs_Control= treatment - control")
+                    ),
+      "model fit"
+    )
+  )
+
+  suppressMessages(
+    expect_null(
+      add_contrasts(input,
+                    contrasts_vector = c("Treatment_vs_Control= treatment - control")
+      )$eBayes_fit
+    )
+  )
+})
+
+# warning when deleting existing results
+test_that("add_contrasts gives warning when deleting existing results", {
+  input <- suppressMessages(
+    readRDS(test_path("fixtures", "add_design_input.rds")) |>
+      add_design(~ 0 + treatment) |>
+      fit_limma_model() |>
+      extract_DA_results()
+  )
+  suppressMessages(
+    expect_message(
+      add_contrasts(input,
+                    contrasts_vector = c("Treatment_vs_Control= treatment - control")
+      ),
+      "results"
+    )
+  )
+
+  suppressMessages(
+    expect_null(
+      add_contrasts(input,
+                    contrasts_vector = c("Treatment_vs_Control= treatment - control")
+      )$results
+    )
+  )
+})
+
+
+
 test_that("add_contrasts outputs proper contrast when contrasts_vector is supplied", {
   input <- readRDS(test_path("fixtures", "add_contrasts_input.rds"))
 

--- a/tests/testthat/test-add_design.R
+++ b/tests/testthat/test-add_design.R
@@ -22,6 +22,31 @@ test_that("add_design gives warning when overwriting an existing statistical des
 
 })
 
+
+# warning when deleting existing model fit
+test_that("add_design gives warning when deleting existing model fit", {
+  input <- suppressMessages(
+    readRDS(test_path("fixtures", "add_design_input.rds")) |>
+      add_design(~ treatment) |>
+      fit_limma_model()
+  )
+  suppressMessages(expect_message(add_design(input, "~ treatment"), "model fit"))
+  suppressMessages(expect_null(add_design(input, "~ treatment")$eBayes_fit))
+})
+
+# warning when deleting existing results
+test_that("add_design gives warning when deleting existing results", {
+  input <- suppressMessages(
+    readRDS(test_path("fixtures", "add_design_input.rds")) |>
+      add_design(~ treatment) |>
+      fit_limma_model() |>
+      extract_DA_results()
+  )
+  suppressMessages(expect_message(add_design(input, "~ treatment"), "results"))
+  suppressMessages(expect_null(add_design(input, "~ treatment")$results))
+})
+
+
 # Error when calling an invalid formula
 # Mostly tested below
 test_that("add_design errors via validate_formula with improper formula", {


### PR DESCRIPTION
The PR adds some behavior to add_contrasts and add_design: if the DAList object contains a model fit or results object, these are reset to NULL. This ensures that the DAList object stays synced, and you can't have a statistical design that does not match the model fit or results.
 
This PR fixes #198 