### PR TITLE
add uams_internal option to report template

### DIFF
--- a/R/limma_report.R
+++ b/R/limma_report.R
@@ -250,11 +250,21 @@ write_limma_plots <- function(DAList = NULL,
   }
 
   # Copy templates over
+  # Sneak a little flag in here to use the proteoDAuams package
+  # when this function is being called for internal UAMS use
+  # Internal UAMS use includes a flag
+  if (!is.null(DAList$tags$uams_internal)) {
+    template_package <- "proteoDAuams"
+  } else {
+    template_package <- "proteoDA"
+  }
+
+
   file.copy(from = system.file("report_templates/glimma_xy_plot.Rmd",
-                               package = "proteoDA"),
+                               package = template_package),
             to = "plot_template.Rmd", overwrite = T)
   file.copy(from = system.file("report_templates/limma_report_per_contrast.Rmd",
-                               package = "proteoDA"),
+                               package = template_package),
             to = "report_template.Rmd", overwrite = T)
 
   # once we create the files, ensure they're deleted if there's an error below

--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -184,8 +184,8 @@ norm_ndu <- norm_ndu |>
   add_contrasts(contrasts_file = "for_testing/Example Data/NDu_030822_DIA/input_files/kidney_contrasts.txt")
 
 # Lupashin
-norm_lupashin <- norm_lupashin |>
-  add_contrasts(contrasts_file = "for_testing/Example Data/lupashin_030222/contrasts_bad.csv")
+# norm_lupashin <- norm_lupashin |>
+#   add_contrasts(contrasts_file = "for_testing/Example Data/lupashin_030222/contrasts_bad.csv")
 norm_lupashin <- norm_lupashin |>
   add_contrasts(contrasts_file = "for_testing/Example Data/lupashin_030222/contrasts.csv")
 


### PR DESCRIPTION
This PR sneaks in a little code flag that switches the source of the Rmd template used for generating the limma report when working with uams internal data. This allows us to use different templates publicly vs internally while minimizing duplcated code to maintain. 