### PR TITLE
fix a bug when user specified table_columns with bad JS colnames

### DIFF
--- a/inst/report_templates/glimma_xy_plot.Rmd
+++ b/inst/report_templates/glimma_xy_plot.Rmd
@@ -7,36 +7,31 @@ if ({{plot}} == "Volcano raw P") {
   xlab <- "logFC"
   ylab <- "negLog10rawP"
   status <- data$sig.PVal
-  cols_to_display <- c(table_columns, "logFC", "p", "adjusted_p")
+  cols_to_display <- c(internal_table_columns, "logFC", "p", "adjusted_p")
 } else if ({{plot}} == "Volcano adjusted P") {
   x <- data$logFC
   y <- data$negLog10adjP
   xlab <- "logFC"
   ylab <- "negLog10adjP"
   status <- data$sig.FDR
-  cols_to_display <- c(table_columns, "logFC", "p", "adjusted_p")
+  cols_to_display <- c(internal_table_columns, "logFC", "p", "adjusted_p")
 } else if ({{plot}} == "MD raw P") {
   x <- data$AveExpr
   y <- data$logFC
   xlab <- "AveExpr"
   ylab <- "logFC"
   status <- data$sig.PVal
-  cols_to_display <- c(table_columns, "AveExpr", "logFC", "p", "adjusted_p")
+  cols_to_display <- c(internal_table_columns, "AveExpr", "logFC", "p", "adjusted_p")
 } else if ({{plot}} == "MD adjusted P") {
   x <- data$AveExpr
   y <- data$logFC
   xlab <- "AveExpr"
   ylab <- "logFC"
   status <- data$sig.FDR
-  cols_to_display <- c(table_columns, "AveExpr", "logFC", "p", "adjusted_p")
+  cols_to_display <- c(internal_table_columns, "AveExpr", "logFC", "p", "adjusted_p")
 } else {
   stop("Invalid plot option")
 }
-
-# Add the non log-10 p values to the annotation data, for use
-# in  the table 
-anno$p <- round(data$P.Value, digits = 4)
-anno$`adjusted_p` <- round(data$adj.P.Val, digits = 4)
 
 uams_glimmaXY(
         x = x,

--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -270,7 +270,8 @@ write_limma_plots(results_reb,
                   title_column = "Accession.Number", overwrite = T)
 
 write_limma_plots(results_reb,
-                  grouping_column = "group")
+                  grouping_column = "group",
+                  output_dir = "reb_s3obj_nocustom", overwrite = T)
 write_limma_plots(results_reb,
                   grouping_column = "group", overwrite = T)
 


### PR DESCRIPTION
A bug that would occur when users specified table columns (or a title column that gets added to the table) that contained names incompatible with JS. I had fixed this issue with PR 192, but didn't check the outputs closely enough: it only worked for the first report. Something was getting overwritten in the later reports for the loop., though print debugging indicated it was all fine. In any case, moving the colname correction outside the loop and differentiating between the original and fixed colnames did the trick.