### PR TITLE
make sure limma report tests clean up after themselves

### DIFF
--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -140,10 +140,6 @@ write_qc_report(norm_reb,
                 overwrite = T, standardize = T, top_proteins = nrow(norm_reb$data),
                 pca_axes = c(2, 5))
 
-write_qc_report(norm_kaul,
-                color_column = "group",
-                filename = "kaul_qc_update.pdf",
-                overwrite = T)
 
 
 # Make design -------------------------------------------------------------
@@ -244,7 +240,7 @@ results_higgs <- extract_DA_results(fit_higgs, extract_intercept = F)
 write_limma_tables(results_lupashin, overwrite = T)
 
 write_limma_tables(results_ndu,
-                   overwrite = F)
+                   overwrite = T)
 
 write_limma_tables(results_ndu_random,
                    output_dir = "Ndu_random_s3obj",
@@ -283,7 +279,8 @@ write_limma_plots(results_reb,
 
 write_limma_plots(results_reb,
                   grouping_column = "group",
-                  output_dir = "reb_s3obj/")
+                  output_dir = "reb_s3obj/",
+                  overwrite = T)
 
 write_limma_plots(results_lupashin,
                   grouping_column = "group",
@@ -316,6 +313,7 @@ write_limma_plots(results_higgs,
                   grouping_column = "group",
                   output_dir = "higgs_s3obj")
 write_limma_plots(results_higgs,
-                  #key_column = "Protein.Name",
+                  title_column = "Protein.Name",
                   grouping_column = "group",
-                  output_dir = "higgs_s3obj")
+                  output_dir = "higgs_s3obj",
+                  overwrite = T)

--- a/tests/testthat/test-limma_report.R
+++ b/tests/testthat/test-limma_report.R
@@ -209,7 +209,8 @@ test_that("write_limma_plots does not alter user working directory", {
   # When specifying custom wd
   on.exit(unlink(c("tempfortesting/control_DA_report.html",
                    "tempfortesting/treatment_DA_report.html",
-                   "tempfortesting/static_plots"), recursive = T), add = T)
+                   "tempfortesting/static_plots",
+                   "tempfortesting/"), recursive = T), add = T)
 
   suppressMessages(
     expect_message(
@@ -241,7 +242,8 @@ test_that("write_limma_plots creates output files", {
                               "static_plots/treatment-volcano-adjusted-pval.pdf",
                               "static_plots/treatment-volcano-raw-pval.pdf")
 
-  on.exit(unlink(expected_files_default, recursive = T), add = T)
+  on.exit(unlink(c(expected_files_default,
+                   "static_plots"), recursive = T), add = T)
 
   suppressMessages(write_limma_plots(input,
                                      grouping_column = "treatment",
@@ -261,7 +263,9 @@ test_that("write_limma_plots creates output files", {
                              "tempfortest/static_plots/treatment-pval-hist.pdf",
                              "tempfortest/static_plots/treatment-volcano-adjusted-pval.pdf",
                              "tempfortest/static_plots/treatment-volcano-raw-pval.pdf")
-  on.exit(unlink(expected_files_custom, recursive = T), add = T)
+  on.exit(unlink(c(expected_files_custom,
+                 "tempfortest/static_plots",
+                 "tempfortest"), recursive = T), add = T)
   suppressMessages(
     write_limma_plots(input,
                       grouping_column = "treatment",


### PR DESCRIPTION
fix an issue where some report files generated during testing weren't deleted.