### PR TITLE
Qc report heatmap

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,5 @@
 ^doc$
 ^Meta$
 ^.github/*$
+^previous/*$
+^update/*$

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ for_testing/bs_tab_listen.Rmd
 .Rdata
 .httr-oauth
 inst/doc
+update/
+previous/
 
 # Some generated stuff in the vignette folder
 vignettes/*.R

--- a/R/qc_report.R
+++ b/R/qc_report.R
@@ -10,7 +10,9 @@
 #'   supplied, all samples will be the same color.
 #' @param label_column Optional. The name of column within the targets data frame
 #'   which contains labels to use for plotting figures. When not supplied,
-#'   defaults to using the column names of the data in processed_data.
+#'   defaults to using the column names of the data in processed_data. To ensure
+#'   good plot formatting, sample labels will be truncated to 20 characters, and
+#'   the function will give an error if the sample labels are not unique.
 #' @param filename The file name of the report to be saved. Must end in .pdf. Will
 #'   default to "QC_Report.pdf" if no filename is provided.
 #' @param top_proteins The number of most variable proteins to use

--- a/R/qc_report.R
+++ b/R/qc_report.R
@@ -123,8 +123,24 @@ write_qc_report <- function(DAList,
                        "i" = "Check the column names with {.code colnames(DAList$metadata)}."))
     }
     sample_labels <- as.character(DAList$metadata[,label_column])
+    if (any(duplicated(sample_labels))) {
+      cli::cli_abort(c("Sample labels in {label_column} column are not unique"))
+    }
   } else { # Use colnames of the data if not provided
     sample_labels <- colnames(DAList$data)
+  }
+
+  # If necessary, truncate sample labels
+  if (any(stringr::str_length(sample_labels) > 20)) {
+    sample_labels <- stringr::str_trunc(sample_labels, width = 20, side = "right")
+    num_too_long <- sum(stringr::str_length(sample_labels) > 20, na.rm = T)
+    cli::cli_inform(c("{cli::qty(num_too_long)} {?A/Some} sample label{?s} longer than 20 characters",
+                      "i" = "Truncating sample labels to 20 characters for plotting"))
+
+    if (any(duplicated(sample_labels))) {
+      cli::cli_abort(c("Sample labels in {label_column} column are not unique after truncation",
+                       "i" = "Modify values in {label_column} or use a different column"))
+    }
   }
 
   ############
@@ -222,11 +238,11 @@ write_qc_report <- function(DAList,
 
   # missing value heatmap <- cluster by grouping column
   miss_heatmap_groups <- qc_missing_hm(data = norm_data,
-                                        groups = groups,
-                                        sample_labels = sample_labels,
-                                        column_sort = "group",
-                                        group_var_name = color_column,
-                                        show_all_proteins = show_all_proteins)
+                                       groups = groups,
+                                       sample_labels = sample_labels,
+                                       column_sort = "group",
+                                       group_var_name = color_column,
+                                       show_all_proteins = show_all_proteins)
 
   ###############################
   ## Save plots, check, return ##
@@ -241,7 +257,10 @@ write_qc_report <- function(DAList,
                        miss_heatmap_cluster,
                        miss_heatmap_groups)
   } else { # when <50 samples, group first plots together on 1 page
-    plots_list <-  list(patchwork::patchworkGrob(violin_plot + pca_plot + dendro_plot),
+    joint_plot <- patchwork::wrap_plots(violin_plot, pca_plot, dendro_plot) &
+      theme(plot.margin = margin(0,0,0,0))
+
+    plots_list <-  list(patchwork::patchworkGrob(joint_plot),
                         correlation_heatmap,
                         miss_heatmap_cluster,
                         miss_heatmap_groups)
@@ -253,11 +272,14 @@ write_qc_report <- function(DAList,
   # If you make changes here, make corresponding changes in the
   # qc_corr_hm and qc_missing_hm functions
   if (ncol(norm_data) > 50) {
-    height <- 17
-    width <- 17
+    # With > 50 samples, sample labels
+    # are in 10 pt font. 72pt per inch
+    # Dynamically size, with a minimum
+    height <- max((10/72)*ncol(norm_data), 14)
+    width <- max((10/72)*ncol(norm_data), 14)
   } else {
-    height <- 8.5
-    width <- 22
+    height <- 10
+    width <- 30
   }
 
   # Then save

--- a/man/write_qc_report.Rd
+++ b/man/write_qc_report.Rd
@@ -28,7 +28,9 @@ supplied, all samples will be the same color.}
 
 \item{label_column}{Optional. The name of column within the targets data frame
 which contains labels to use for plotting figures. When not supplied,
-defaults to using the column names of the data in processed_data.}
+defaults to using the column names of the data in processed_data. To ensure
+good plot formatting, sample labels will be truncated to 20 characters, and
+the function will give an error if the sample labels are not unique.}
 
 \item{output_dir}{The directory in which to save the report. If the directory
 does not exist, it will be created. If not provided, will default to

--- a/tests/test_workflow.R
+++ b/tests/test_workflow.R
@@ -97,46 +97,99 @@ full_higgs_chain <- higgs |>
   filter_proteins_by_proportion(min_prop = 1) |>
   normalize_data(norm_method = "cycloess")
 
-write_qc_report(full_higgs_chain,
-                color_column = "group",
-                filename = "higgs_qc_update.pdf",
-                overwrite = T)
 
 write_qc_report(full_higgs_chain,
-                output_dir = "temp",
+                output_dir = "update",
                 color_column = "group",
-                filename = "higgs_qc_update.pdf",
+                filename = "higgs_qc.pdf",
                 overwrite = T)
 
+# To test longer IDs, reverse the
+# sample ID strings so they're still unique after truncation
+full_higgs_chain$metadata$sampleIDs_rev <- stringi::stri_reverse(full_higgs_chain$metadata$sampleIDs)
 write_qc_report(full_higgs_chain,
+                output_dir = "update",
                 color_column = "group",
-                label_column = "sampleIDs",
-                filename = "higgs_qc_update_samplelabs.pdf",
+                label_column = "sampleIDs_rev",
+                filename = "higgs_qc_samplelabs.pdf",
+                overwrite = T)
+
+# Some "normal" ones
+write_qc_report(norm_ndu,
+                output_dir = "update",
+                color_column = "group",
+                filename = "ndu_qc.pdf",
                 overwrite = T)
 
 write_qc_report(norm_ndu,
-                color_column = "group",
-                filename = "ndu_qc_update.pdf",
-                overwrite = T)
-
-write_qc_report(norm_ndu,
-                filename = "ndu_qc_update_batch.pdf",
+                output_dir = "update",
+                filename = "ndu_qc_batch.pdf",
                 overwrite = T)
 
 
 write_qc_report(norm_lupashin,
+                output_dir = "update",
                 color_column = "group",
-                filename = "lupashin_qc_update.pdf",
+                filename = "lupashin_qc.pdf",
                 overwrite = T)
+
+# Use the Zhan data to test different sizes:
+# really big (regular data)
+# just over 50, and
+# just under 50
+norm_zhan$metadata$long_ID <- stringr::str_pad(norm_zhan$metadata$sample, width = 25, side = "right", pad = "X")
+norm_zhan_50 <- norm_zhan %>%
+  filter_samples(as.numeric(number) %% 2 == 0) %>%
+  filter_samples(rep(c(T, F), times = 54))
+
+norm_zhan_49 <- norm_zhan %>%
+  filter_samples(as.numeric(number) %% 2 == 0) %>%
+  filter_samples(c(rep(c(T, F), times = 49), rep(F, 10)))
 
 write_qc_report(norm_zhan,
+                output_dir = "update",
                 color_column = "group",
-                filename = "zhan_qc_update.pdf",
+                filename = "zhan_qc.pdf",
+                overwrite = T)
+write_qc_report(norm_zhan,
+                output_dir = "update",
+                label_column = "long_ID",
+                color_column = "group",
+                filename = "zhan_qc_ids.pdf",
                 overwrite = T)
 
-write_qc_report(norm_reb,
+
+write_qc_report(norm_zhan_50,
+                output_dir = "update",
                 color_column = "group",
-                filename = "rebello_qc_update_changes.pdf",
+                filename = "zhan54_qc.pdf",
+                overwrite = T)
+write_qc_report(norm_zhan_50,
+                output_dir = "update",
+                label_column = "long_ID",
+                color_column = "group",
+                filename = "zhan54_qc_ids.pdf",
+                overwrite = T)
+
+
+write_qc_report(norm_zhan_49,
+                output_dir = "update",
+                color_column = "group",
+                filename = "zhan49_qc.pdf",
+                overwrite = T)
+write_qc_report(norm_zhan_49,
+                output_dir = "update",
+                label_column = "long_ID",
+                color_column = "group",
+                filename = "zhan49_qc_ids.pdf",
+                overwrite = T)
+
+
+
+write_qc_report(norm_reb,
+                output_dir = "update",
+                color_column = "group",
+                filename = "rebello_qc.pdf",
                 overwrite = T, standardize = T, top_proteins = nrow(norm_reb$data),
                 pca_axes = c(2, 5))
 

--- a/tests/testthat/test-limma_tables.R
+++ b/tests/testthat/test-limma_tables.R
@@ -109,6 +109,7 @@ test_that("write_limma_tables informs user of output dir and filenames when not 
 
   on.exit(unlink(c("per_contrast_results/control.csv",
                    "per_contrast_results/treatment.csv",
+                   "per_contrast_results",
                    "DA_summary.csv",
                    "combined_results.csv",
                    "results.xlsx"), recursive = T), add = T)
@@ -184,7 +185,9 @@ test_that("write_limma_tables messages user when overwriting", {
                    "per_contrast_results/treatment.csv",
                    "DA_summary.csv",
                    "combined_results.csv",
-                   "results.xlsx"), recursive = T), add = T)
+                   "results.xlsx",
+                   "per_contrast_results"),
+                 recursive = T), add = T)
 
   suppressMessages(write_limma_tables(input))
   suppressMessages(
@@ -206,7 +209,9 @@ test_that("write_limma_tables creates output files", {
                                "combined_results.csv",
                                "results.xlsx")
 
-  on.exit(unlink(expected_files_default, recursive = T), add = T)
+  on.exit(unlink(c(expected_files_default,
+                   "per_contrast_results"),
+                 recursive = T), add = T)
 
   suppressMessages(write_limma_tables(input, overwrite = F))
   expect_true(all(file.exists(expected_files_default)))
@@ -217,7 +222,9 @@ test_that("write_limma_tables creates output files", {
                                "tempfortest/sum.csv",
                                "tempfortest/combo.csv",
                                "tempfortest/res.xlsx")
-  on.exit(unlink(expected_files_custom, recursive = T), add = T)
+  on.exit(unlink(c(expected_files_custom,
+                   "tempfortest"),
+                 recursive = T), add = T)
   suppressMessages(
     write_limma_tables(input,
                        output_dir = "tempfortest",


### PR DESCRIPTION
This PR address one of the reviewer comments for the JOSS manuscript. It modifies the QC report (`write_qc_report()`) to make them a little nicer and easier to read:

1. When there are > 50 samples, the output files are now dynamically sized (with a minimum), to avoid issues of label overlap when there are many samples. 
2. For all plots, there is some updated handling of sample labels: labels that are longer than 20 characters are truncated (with a warning), and the code checks for non-unique sample labels (generates an error if they aren't unique). This allows us to handle plot sizing with some known label size constraints and avoid labels running over plot edges or over legends. When necessary, we also do some dynamic margin sizing based on the length of the longest label, to doubly-ensure no label overruns. 
3. Font sizes for all legends are increased in size, to make them a little easier to read.
4. All PDF outputs have been made a little bigger, for readability.

This PR also contains new tests for the QC report, and fixes a bug in the other test code that allowed some empty test folders ot hang around. 