### PR TITLE
Convert input tibbles to data frames with warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: proteoDA
 Title: Streamlined Differential Abundance Analysis of Proteomic Data
-Version: 0.0.0.9002
+Version: 1.0.1
 Authors@R: 
     c(
       person(given = "Timothy", family = "Thurman", email = "tthurman@uams.edu", role = c("aut", "cre")),
@@ -37,6 +37,7 @@ Depends:
 Suggests:
     grDevices,
     ggrastr,
+    tibble,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/R/s3_class.R
+++ b/R/s3_class.R
@@ -125,6 +125,29 @@ DAList <- function(data,
                    results = NULL,
                    tags = NULL) {
 
+  # Check if data, annotation, and metadata
+  # are tibble, convert to data frames if so.
+  if (any(c("tbl_df", "tbl") %in% class(data))) {
+    cli::cli_warn(
+      "Input data is a tibble, converting to data frame"
+    )
+    data <- as.data.frame(data)
+  }
+
+  if (any(c("tbl_df", "tbl") %in% class(annotation))) {
+    cli::cli_warn(
+      "Input annotation is a tibble, converting to data frame"
+    )
+    annotation <- as.data.frame(annotation)
+  }
+
+  if (any(c("tbl_df", "tbl") %in% class(metadata))) {
+    cli::cli_warn(
+      "Input metadata is a tibble, converting to data frame"
+    )
+    metadata <- as.data.frame(metadata)
+  }
+
   # Check for a uniprot_id column in annotation
   if ("uniprot_id" %notin% colnames(annotation)) {
     cli::cli_abort(
@@ -204,6 +227,25 @@ validate_DAList <- function(x) {
   }
 
   ## Check each element
+
+  # Make sure data aren't tibbles
+  if (any(c("tbl_df", "tbl") %in% class(x$data))) {
+    cli::cli_abort(
+      "Data slot is a tibble, must be a matrix or data frame"
+    )
+  }
+
+  if (any(c("tbl_df", "tbl") %in% class(x$annotation))) {
+    cli::cli_abort(
+      "Annotation slot is a tibble, must be a matrix or data frame"
+    )
+  }
+
+  if (any(c("tbl_df", "tbl") %in% class(x$metadata))) {
+    cli::cli_abort(
+      "Metadata slot is a tibble, must be a matrix or data frame"
+    )
+  }
 
   # Data
   if (!any(c(is.data.frame(x$data), is.matrix(x$data)))) {


### PR DESCRIPTION
The DAList() function now converts input tibbles to dataframes, and the validator checks that the data, annotation, and metadata slots in a DAList do not contain tibbles. This should avoid the issue reported in #251, which occurred because of tibbles in the downstream analysis.

Updates version to 1.0.1
Fixes #251